### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         "project-manager": "project-manager"
       },
       "locked": {
-        "lastModified": 1701830746,
-        "narHash": "sha256-zz1s2oX2KDwmbvzt9gA2Vr2em326MHTNLzuIe0mQnKs=",
+        "lastModified": 1702402116,
+        "narHash": "sha256-ruM8VVA/LWis7qRryjQIuMx2jAQxwVd7XuEDMVobQDs=",
         "owner": "sellout",
         "repo": "flaky",
-        "rev": "8691b17f09623141e1707a4e845dec1fd9f05d77",
+        "rev": "d3fd32e4e39e3ddce418fe32fc15167a9761d542",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702162613,
-        "narHash": "sha256-C8LiSEbppgZK2lrgvziachUcBXrraZm1IAqgYBWZSYc=",
+        "lastModified": 1702424505,
+        "narHash": "sha256-Mj4Unppuzd05/JFrTQ+i/8+td0MRnaHpp+hInzkAo2A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98ca82c313df5205aa3e41a7ec59bee13551303a",
+        "rev": "a46b965ea7d1b9587a46f91adfdbac29e56c9b87",
         "type": "github"
       },
       "original": {
@@ -263,11 +263,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1701722994,
-        "narHash": "sha256-I6Ytrc2B3JII5WXwuucWZRlRRaJJeX9HLoAFNAje5dk=",
+        "lastModified": 1701854477,
+        "narHash": "sha256-O+Psfu6mj9yzJzkjz3mbqtusmtk07MkHy99lebsOxG0=",
         "owner": "sellout",
         "repo": "project-manager",
-        "rev": "2e8c650429995db4988681671cb0ec31da5fb4c9",
+        "rev": "d146c153ad35040bcf666798a4d18ee045ae9daf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This gives us the latest Project Manager, which does a better job with
unsandboxed checks and no longer provides the default devShell.